### PR TITLE
Fix URLs and packaging scheme

### DIFF
--- a/Casks/warp-cli.rb
+++ b/Casks/warp-cli.rb
@@ -1,11 +1,11 @@
 cask "warp-cli" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "0.2025.09.11.08.11.dev_00"
-  sha256 arm:   "<placeholder>",
-         intel: "<placeholder>"
+  version "0.2025.09.17.08.11.stable_00"
+  sha256 arm:   "80c96b19e09c8c83b3ff42a9509d0e354f3d471eb4b60ef3a2d4653eeecf3477",
+         intel: "4b0eed6ff3e473bd47e0518a192f935e2192a7bd6294f66a17fe3bdd2c3f8bdd"
 
-  url "https://app.warp.dev/download/cli?os=macos&package=standalone&arch=#{arch}&version=v#{version}"
+  url "https://app.warp.dev/download/cli?os=macos&package=tar&arch=#{arch}&version=v#{version}"
   name "Warp CLI"
   desc "Command-line interface to Warp agents"
   homepage "https://www.warp.dev/"

--- a/Casks/warp-cli@preview.rb
+++ b/Casks/warp-cli@preview.rb
@@ -1,11 +1,11 @@
 cask "warp-cli@preview" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "0.2025.09.03.08.11.preview_01"
-  sha256 arm:   "<placeholder>",
-         intel: "<placeholder>"
+  version "0.2025.09.17.08.11.preview_00"
+  sha256 arm:   "5b46798e5575fb13e2e0a5f848e297a67c969ee87af84bf67b80d7dc03fd4c45",
+         intel: "cac930991a7c0e3fdf933948ebbde7513ba0516a7fe1307e439c56e3576b19ac"
 
-  url "https://app.warp.dev/download/cli?channel=preview&os=macos&package=standalone&arch=#{arch}&version=v#{version}"
+  url "https://app.warp.dev/download/cli?channel=preview&os=macos&package=tar&arch=#{arch}&version=v#{version}"
   name "Warp CLI (Preview)"
   desc "Command-line interface to Warp agents"
   homepage "https://www.warp.dev/"


### PR DESCRIPTION
A few changes to get this ready:
* Update the container spec to reflect switching to `.tar.gz` bundles
* Fix query params in the download URL

Hashes are explicit placeholders, since the binaries for next week's release haven't been built yet.
