### PR TITLE
Prep for stable release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, macos-15 ]
+        os: [ macos-13, macos-15 ]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read

--- a/Casks/warp-cli.rb
+++ b/Casks/warp-cli.rb
@@ -17,5 +17,5 @@ cask "warp-cli" do
     end
   end
 
-  binary "warp"
+  binary "warp-stable", target: "warp"
 end


### PR DESCRIPTION
Two more launch-readiness fixes:
1. Rename the `warp-stable` binary from the `.tar.gz` bundle to `warp`
2. Don't try to test on Ubuntu, as these casks are macOS-only

