### PR TITLE
Update oz cask livecheck to handle cli_version and macOS platform overrides

### DIFF
--- a/Casks/oz.rb
+++ b/Casks/oz.rb
@@ -13,7 +13,24 @@ cask "oz" do
   livecheck do
     url "https://releases.warp.dev/channel_versions.json"
     strategy :json do |json|
-      json.dig("stable", "version")&.delete_prefix("v")
+      channel = json["stable"]
+      next if channel.nil?
+
+      # Start with base channel values.
+      version = channel["version"]
+      cli_version = channel["cli_version"]
+
+      # Apply macOS-specific override if present (mirrors the Rust apply_override logic:
+      # `version` is always replaced; `cli_version` only if the override sets it).
+      mac_override = channel["overrides"]&.find { |o| o.dig("predicate", "target_os") == "macos" }
+      if mac_override
+        info = mac_override["version_info"]
+        version = info["version"] if info&.key?("version")
+        cli_version = info["cli_version"] if info&.key?("cli_version")
+      end
+
+      # Prefer cli_version, fall back to version.
+      (cli_version || version)&.delete_prefix("v")
     end
   end
 

--- a/Casks/oz@preview.rb
+++ b/Casks/oz@preview.rb
@@ -13,7 +13,24 @@ cask "oz@preview" do
   livecheck do
     url "https://releases.warp.dev/channel_versions.json"
     strategy :json do |json|
-      json.dig("preview", "version")&.delete_prefix("v")
+      channel = json["preview"]
+      next if channel.nil?
+
+      # Start with base channel values.
+      version = channel["version"]
+      cli_version = channel["cli_version"]
+
+      # Apply macOS-specific override if present (mirrors the Rust apply_override logic:
+      # `version` is always replaced; `cli_version` only if the override sets it).
+      mac_override = channel["overrides"]&.find { |o| o.dig("predicate", "target_os") == "macos" }
+      if mac_override
+        info = mac_override["version_info"]
+        version = info["version"] if info&.key?("version")
+        cli_version = info["cli_version"] if info&.key?("cli_version")
+      end
+
+      # Prefer cli_version, fall back to version.
+      (cli_version || version)&.delete_prefix("v")
     end
   end
 


### PR DESCRIPTION
## Summary

Updates the livecheck in `oz.rb` and `oz@preview.rb` to properly resolve the CLI version from `channel_versions.json`, handling two previously unsupported features:

1. **`cli_version` override**: The CLI ships on a different release cadence than the main Warp app. The JSON now has a `cli_version` field that should be preferred over `version` for CLI cask version checks.

2. **macOS platform override**: The JSON supports an `overrides` array with per-platform entries (e.g., `target_os: "macos"`). When a macOS override exists, its fields are merged onto the base channel info before resolving the CLI version.

The Ruby logic mirrors the Rust `apply_override` semantics from `warp-internal/crates/channel_versions`:
- `version` is always replaced by the override
- `cli_version` is only replaced if the override explicitly sets it
- Final version = `cli_version ?? version`

_Conversation: https://staging.warp.dev/conversation/0fe3c56e-7c32-4fac-8061-4527d205a20b_
_Run: https://oz.staging.warp.dev/runs/019d92d8-2335-72fd-95a4-d8368c19605b_

_This PR was generated with [Oz](https://warp.dev/oz)._
