### PR TITLE
ci: use squash automerge for channel version updates

### DIFF
--- a/.github/workflows/update_channel_versions.yml
+++ b/.github/workflows/update_channel_versions.yml
@@ -18,7 +18,7 @@ jobs:
           # We use the GitHub Actions token to approve, rather than the warpmachineuser PAT, since users can't approve their own PRs.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable automerge
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           # We use the warpmachineuser PAT to enable automerge, as the GitHub Actions token cannot do so.

--- a/Casks/oz.rb
+++ b/Casks/oz.rb
@@ -1,9 +1,9 @@
 cask "oz" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "0.2026.04.08.08.36.stable_02"
-  sha256 arm:   "d0b916b4f1f89282a5542371cac6cbf57df2ad084973a5bd902b2272af07e2c7",
-         intel: "6bb99e258cab78d0fb81ca8fd17fa2d3c890ecae219a0a6c3a6a3377326097ce"
+  version "0.2026.05.27.15.44.stable_01"
+  sha256 arm:   "5879f4ccffb6fa040b087c54687b93b8b13b4fa3223e61b2c815f3ff758e961e",
+         intel: "b357d18d6e3a5370dcec11737da6af227e9b195ed56b40ceb807e52957faa33f"
 
   url "https://app.warp.dev/download/cli?os=macos&package=tar&arch=#{arch}&version=v#{version}"
   name "Oz"

--- a/Casks/oz.rb
+++ b/Casks/oz.rb
@@ -17,7 +17,7 @@ cask "oz" do
     end
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   binary "oz-stable", target: "oz"
 end

--- a/Casks/oz@preview.rb
+++ b/Casks/oz@preview.rb
@@ -17,7 +17,7 @@ cask "oz@preview" do
     end
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   binary "oz-preview"
 end

--- a/Casks/oz@preview.rb
+++ b/Casks/oz@preview.rb
@@ -1,9 +1,9 @@
 cask "oz@preview" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "0.2026.04.08.08.36.preview_02"
-  sha256 arm:   "4b28282446eba520b657364ebcb166455ccc43a37352ce91c254b66160a44cae",
-         intel: "a11db2c36f94a2e2d0d7b9c9ec6a158944a0b1d9d33a104a463bbcd94063d77b"
+  version "0.2026.05.27.15.44.preview_01"
+  sha256 arm:   "8ac9bf8ab506324513e4fefee9eae714541f26a04bb509b8692d76afc6dff3a2",
+         intel: "a7e6152eb8d28d2e890a2ab312f13b72bacf06ba6675b3e71b622859fd227605"
 
   url "https://app.warp.dev/download/cli?channel=preview&os=macos&package=tar&arch=#{arch}&version=v#{version}"
   name "Oz (Preview)"


### PR DESCRIPTION
## Summary
- Update the channel version auto-merge workflow to request squash auto-merge instead of merge commits.
- Update the Oz and Oz Preview casks to the latest livecheck versions from the blocked bot PRs (#158 and #159).
- Apply Homebrew’s preferred `depends_on macos: :sonoma` syntax for both casks.

## Testing
- `git diff --check`
- `gh pr checks 160 --repo warpdotdev/homebrew-warp --watch --interval 20` → all checks successful

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/285e4d67-e3a3-43a8-bf12-94ef92b134fa_
_Run: https://oz.staging.warp.dev/runs/019e8fd1-8f13-7a77-939d-483873101409_
_Plans_:
- _[Fix homebrew-warp PR #160 CI failures](https://staging.warp.dev/drive/notebook/fI418Mq0aTNlwGdAufR2wY)_
_This PR was generated with [Oz](https://warp.dev/oz)._
